### PR TITLE
Add main.js entry point with 60 FPS render loop

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 function setup() {
   createCanvas(CONFIG.width, CONFIG.height);
+  frameRate(60);
   Simulation.init();
 }
 


### PR DESCRIPTION
## Summary
- Add explicit `frameRate(60)` call in setup() to ensure consistent 60 FPS render loop
- Completes the p5.js entry point implementation for the simulation

Closes #6

## Test plan
- [ ] Open index.html in browser
- [ ] Verify ball spawns at center and moves in random direction
- [ ] Verify ball bounces off ring continuously
- [ ] Verify no console errors
- [ ] Run simulation for 60 seconds without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)