### PR TITLE
Extend Ring class with gap support

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -14,5 +14,6 @@ const CONFIG = {
     thickness: 8,
     color: '#4444ff',
     segments: 48,
+    gapSize: 45, // Gap size in degrees
   },
 };

--- a/js/ring.js
+++ b/js/ring.js
@@ -1,7 +1,7 @@
 // Ring class - Issue #4
 
 class Ring {
-  constructor(x, y, radius, thickness, color) {
+  constructor(x, y, radius, thickness, color, gapStart = 0, gapSize = 0) {
     this.x = x;
     this.y = y;
     this.radius = radius;
@@ -9,11 +9,40 @@ class Ring {
     this.color = color;
     this.segments = CONFIG.rings.segments;
     this.bodies = [];
+    this.gapStart = gapStart; // Starting angle of gap (radians)
+    this.gapSize = gapSize;   // Size of gap (radians)
+  }
+
+  isInGap(angle) {
+    if (this.gapSize === 0) return false;
+
+    // Normalize angle to [0, TWO_PI)
+    let normalizedAngle = angle % TWO_PI;
+    if (normalizedAngle < 0) normalizedAngle += TWO_PI;
+
+    // Normalize gap start to [0, TWO_PI)
+    let normalizedGapStart = this.gapStart % TWO_PI;
+    if (normalizedGapStart < 0) normalizedGapStart += TWO_PI;
+
+    const gapEnd = normalizedGapStart + this.gapSize;
+
+    // Check if angle is within gap (handle wrap-around)
+    if (gapEnd <= TWO_PI) {
+      return normalizedAngle >= normalizedGapStart && normalizedAngle < gapEnd;
+    } else {
+      // Gap wraps around TWO_PI
+      return normalizedAngle >= normalizedGapStart || normalizedAngle < (gapEnd - TWO_PI);
+    }
   }
 
   create(world) {
     for (let i = 0; i < this.segments; i++) {
       const angle = (TWO_PI / this.segments) * i;
+
+      // Skip segments that fall within the gap
+      if (this.isInGap(angle)) {
+        continue;
+      }
 
       // Segment position (on the ring radius)
       const segX = this.x + cos(angle) * this.radius;
@@ -54,7 +83,17 @@ class Ring {
     noFill();
     stroke(this.color);
     strokeWeight(this.thickness);
-    ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
+
+    if (this.gapSize === 0) {
+      // No gap - draw full circle
+      ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
+    } else {
+      // Draw arc excluding the gap
+      const arcStart = this.gapStart + this.gapSize;
+      const arcEnd = this.gapStart + TWO_PI;
+      arc(this.x, this.y, this.radius * 2, this.radius * 2, arcStart, arcEnd);
+    }
+
     pop();
   }
 }

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -17,12 +17,16 @@ const Simulation = {
     // Create ring at center of canvas
     const centerX = CONFIG.width / 2;
     const centerY = CONFIG.height / 2;
+    const gapStart = random(0, TWO_PI);
+    const gapSize = (CONFIG.rings.gapSize * PI) / 180; // Convert degrees to radians
     this.ring = new Ring(
       centerX,
       centerY,
       CONFIG.rings.innerRadius,
       CONFIG.rings.thickness,
-      CONFIG.rings.color
+      CONFIG.rings.color,
+      gapStart,
+      gapSize
     );
     this.ring.create(this.world);
 


### PR DESCRIPTION
## Summary
- Add `gapStart` and `gapSize` properties to Ring class
- Add `isInGap()` method to determine if angle falls within gap region
- Skip physics body creation for segments in the gap
- Render arc instead of full ellipse when gap is present

## Test plan
- [ ] Ring renders with visible gap at random position
- [ ] Ball bounces off ring segments normally
- [ ] Ball passes through gap without collision

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)